### PR TITLE
 Improve RGBA texture loading times. Add support for OpenGL compressed textures (ETC2)

### DIFF
--- a/android/java/org/mozilla/vrb/ImageLoader.java
+++ b/android/java/org/mozilla/vrb/ImageLoader.java
@@ -8,18 +8,23 @@ package org.mozilla.vrb;
 import android.content.res.AssetManager;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.opengl.ETC1;
 import android.support.annotation.Keep;
-import android.util.Log;
+
+import org.mozilla.vrb.etc2.UtilETC2;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import static android.opengl.GLES30.*;
 
 class ImageLoader {
 
-    @Keep
-    private static void loadFromInputStream(InputStream aInputStream, final String aFileName, final long aFileReader, final int aTrackingHandle) {
+    private static void loadBitmapFromInputStream(InputStream aInputStream, final String aFileName, final long aFileReader, final int aTrackingHandle) {
         try {
             if (aInputStream == null) {
                 ImageLoadFailed(aFileReader, aTrackingHandle, "Unable to find image: " + aFileName);
@@ -30,22 +35,62 @@ class ImageLoader {
                 ImageLoadFailed(aFileReader, aTrackingHandle, "Unable to find image: " + aFileName);
                 return;
             }
-            final int[] pixels = new int[image.getByteCount() / 4];
-            try {
-                final int width  = image.getWidth();
-                final int height = image.getHeight();
-                image.getPixels(pixels, /* offset */ 0, /* stride */ width,
-                        /* x */ 0, /* y */ 0, width, height);
-                ProcessImage(aFileReader, aTrackingHandle, pixels, width, height);
-
-            } catch (final Exception e) {
-                Log.e("VRB", "Can not load texture image: " + aFileName, e);
-                String reason = "Failed to getPixels from bitmap loaded from file: " + aFileName + " (" + e.toString() + ")";
-                ImageLoadFailed(aFileReader, aTrackingHandle, reason);
-            }
+            final int width  = image.getWidth();
+            final int height = image.getHeight();
+            ByteBuffer pixels = ByteBuffer.allocateDirect(image.getAllocationByteCount()).order(ByteOrder.BIG_ENDIAN);
+            image.copyPixelsToBuffer(pixels);
+            ProcessImage(aFileReader, aTrackingHandle, pixels, width, height, GL_RGBA); 
         } catch(Exception e) {
             String reason = "Error loading image file: " + aFileName + " (" + e.toString() + ")";
             ImageLoadFailed(aFileReader, aTrackingHandle, reason);
+        }
+    }
+
+    private static void loadETC2FromInputStream(InputStream aInputStream, final String aFileName, final long aFileReader, final int aTrackingHandle) {
+        try {
+            if (aInputStream == null) {
+                ImageLoadFailed(aFileReader, aTrackingHandle, "Unable to find image: " + aFileName);
+                return;
+            }
+            byte[] buffer = new byte[4096];
+            if (aInputStream.read(buffer, 0, ETC1.ETC_PKM_HEADER_SIZE) != ETC1.ETC_PKM_HEADER_SIZE) {
+                ImageLoadFailed(aFileReader, aTrackingHandle, "Couldn't read PKM header: " + aFileName);
+                return;
+            }
+            ByteBuffer header = ByteBuffer.allocateDirect(ETC1.ETC_PKM_HEADER_SIZE).order(ByteOrder.BIG_ENDIAN);
+            header.put(buffer, 0, ETC1.ETC_PKM_HEADER_SIZE).position(0);
+            if (!UtilETC2.isValid(header)) {
+                ImageLoadFailed(aFileReader, aTrackingHandle, "Invalid PKM header: " + aFileName);
+                return;
+            }
+            int width = UtilETC2.getWidth(header);
+            int height = UtilETC2.getHeight(header);
+            int format = UtilETC2.getETC2CompressionType(header);
+            final int encodedSize = UtilETC2.getEncodedDataSize(width, height);
+            final ByteBuffer dataBuffer = ByteBuffer.allocateDirect(encodedSize).order(ByteOrder.BIG_ENDIAN);
+            for (int i = 0; i < encodedSize; ) {
+                int chunkSize = Math.min(buffer.length, encodedSize - i);
+                if (aInputStream.read(buffer, 0, chunkSize) != chunkSize) {
+                    ImageLoadFailed(aFileReader, aTrackingHandle, "Error reading PKM data: " + aFileName);
+                    return;
+                }
+                dataBuffer.put(buffer, 0, chunkSize);
+                i += chunkSize;
+            }
+            dataBuffer.position(0);
+            ProcessImage(aFileReader, aTrackingHandle, dataBuffer, width, height, format);
+        } catch(Exception e) {
+            String reason = "Error loading image file: " + aFileName + " (" + e.toString() + ")";
+            ImageLoadFailed(aFileReader, aTrackingHandle, reason);
+        }
+    }
+
+    @Keep
+    private static void loadFromInputStream(InputStream aInputStream, final String aFileName, final long aFileReader, final int aTrackingHandle) {
+        if (aFileName.toLowerCase().endsWith(".pkm")) {
+            loadETC2FromInputStream(aInputStream, aFileName, aFileReader, aTrackingHandle);
+        } else {
+            loadBitmapFromInputStream(aInputStream, aFileName, aFileReader, aTrackingHandle);
         }
     }
 
@@ -72,9 +117,10 @@ class ImageLoader {
     private native static void ProcessImage(
             final long aFileReader,
             final int aTrackingHandle,
-            final int[] aPixels,
+            final ByteBuffer aBuffer,
             final int aWidth,
-            final int aHeight);
+            final int aHeight,
+            final int aFormat);
 
     private native static void ImageLoadFailed(final long aFileReader, final int aTrackingHandle, final String aReason);
 }

--- a/android/java/org/mozilla/vrb/etc2/LICENSE
+++ b/android/java/org/mozilla/vrb/etc2/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2013 Dennis Ippel
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/android/java/org/mozilla/vrb/etc2/README
+++ b/android/java/org/mozilla/vrb/etc2/README
@@ -1,0 +1,1 @@
+UtilETC2 code taken taken from here: https://github.com/Rajawali/Rajawali/blob/master/rajawali/src/main/java/org/rajawali3d/materials/textures/utils/ETC2Util.java

--- a/android/java/org/mozilla/vrb/etc2/UtilETC2.java
+++ b/android/java/org/mozilla/vrb/etc2/UtilETC2.java
@@ -1,0 +1,196 @@
+package org.mozilla.vrb.etc2;
+
+import android.opengl.GLES11Ext;
+
+import java.nio.ByteBuffer;
+
+import static android.opengl.GLES30.GL_COMPRESSED_R11_EAC;
+import static android.opengl.GLES30.GL_COMPRESSED_RG11_EAC;
+import static android.opengl.GLES30.GL_COMPRESSED_RGB8_ETC2;
+import static android.opengl.GLES30.GL_COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2;
+import static android.opengl.GLES30.GL_COMPRESSED_RGBA8_ETC2_EAC;
+
+/**
+ * Parsing and data utility class for ETC2 textures.
+ *
+ * @author Jared Woolston (jwoolston@tenkiv.com)
+ */
+public class UtilETC2 {
+
+    /**
+     * The magic sequence for an ETC1 file.
+     */
+    private static final byte ETC1Magic[] = {
+            0x50, //'P'
+            0x4B, //'K'
+            0x4D, //'M'
+            0x20, //' '
+            0x31, //'1'
+            0x30  //'0'
+    };
+
+    /**
+     * The magic sequence for an ETC2 file.
+     */
+    private static final byte ETC2Magic[] = {
+            0x50, //'P'
+            0x4B, //'K'
+            0x4D, //'M'
+            0x20, //' '
+            0x32, //'2'
+            0x30  //'0'
+    };
+
+    /**
+     * File header offsets.
+     */
+    private static final int ETC2_PKM_FORMAT_OFFSET = 6;
+    private static final int ETC2_PKM_ENCODED_WIDTH_OFFSET = 8;
+    private static final int ETC2_PKM_ENCODED_HEIGHT_OFFSET = 10;
+    private static final int ETC2_PKM_WIDTH_OFFSET = 12;
+    private static final int ETC2_PKM_HEIGHT_OFFSET = 14;
+
+    /**
+     * These are the supported PKM format identifiers for the PKM header. The sRGB formats are missing here because I was
+     * not able to get header file information for them. This is the only thing preventing them from being supported.
+     */
+    private static final short ETC1_RGB8_OES = 0x0000;
+    private static final short RGB8_ETC2 = 0x0001;
+    private static final short RGBA8_ETC2_EAC = 0x0003;
+    private static final short RGB8_PUNCHTHROUGH_ALPHA1_ETC2 = 0x0004;
+    private static final short R11_EAC = 0x0005;
+    private static final short RG11_EAC = 0x0006;
+    private static final short SIGNED_R11_EAC = 0x0007;
+    private static final short SIGNED_RG11_EAC = 0x0008;
+
+    /**
+     * Checks the provided file header and determines if this is a valid ETC2 file.
+     *
+     * @param header {@link ByteBuffer} The PKM file header.
+     * @return {@code boolean} True if the file header is valid.
+     */
+    public static boolean isValid(ByteBuffer header) {
+        // First check the ETC2 magic sequence
+        if ((ETC2Magic[0] != header.get(0)) && (ETC2Magic[1] != header.get(1)) && (ETC2Magic[2] != header.get(2))
+                && (ETC2Magic[3] != header.get(3)) && (ETC2Magic[4] != header.get(4)) && (ETC2Magic[5] != header.get(5))) {
+            // Check to see if we are ETC1 instead
+            if ((ETC1Magic[0] != header.get(0)) && (ETC1Magic[1] != header.get(1)) && (ETC1Magic[2] != header.get(2))
+                    && (ETC1Magic[3] != header.get(3)) && (ETC1Magic[4] != header.get(4)) && (ETC1Magic[5] != header.get(5))) {
+                return false;
+            }
+        }
+
+        // Second check the type
+        final short ETC2_FORMAT = header.getShort(ETC2_PKM_FORMAT_OFFSET);
+        switch (ETC2_FORMAT) {
+            case ETC1_RGB8_OES:
+            case RGB8_ETC2:
+            case RGBA8_ETC2_EAC:
+            case RGB8_PUNCHTHROUGH_ALPHA1_ETC2:
+            case R11_EAC:
+            case RG11_EAC:
+            case SIGNED_R11_EAC:
+            case SIGNED_RG11_EAC:
+                break;
+            default:
+                return false;
+        }
+
+        final int encodedWidth = getEncodedWidth(header);
+        final int encodedHeight = getEncodedHeight(header);
+        final int width = getWidth(header);
+        final int height = getHeight(header);
+
+        // Check the width
+        if (encodedWidth < width || (encodedWidth - width) > 4) {
+            return false;
+        }
+        // Check the height
+        if (encodedHeight < height || (encodedHeight - height) > 4) {
+            return false;
+        }
+
+        // We passed all the checks, return true
+        return true;
+    }
+
+    /**
+     * Retrieves the particular compression format for the ETC2 Texture.
+     *
+     * @param header {@link ByteBuffer} The PKM file header.
+     * @return {@code int} One of the GL_COMPRESSED_* types for ETC2, or -1 if unrecognized.
+     */
+    public static int getETC2CompressionType(ByteBuffer header) {
+        switch (header.getShort(ETC2_PKM_FORMAT_OFFSET)) {
+            case ETC1_RGB8_OES:
+                return GLES11Ext.GL_ETC1_RGB8_OES;
+            case RGB8_ETC2:
+                return GL_COMPRESSED_RGB8_ETC2;
+            case RGBA8_ETC2_EAC:
+                return GL_COMPRESSED_RGBA8_ETC2_EAC;
+            case RGB8_PUNCHTHROUGH_ALPHA1_ETC2:
+                return GL_COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2;
+            case R11_EAC:
+                return GL_COMPRESSED_R11_EAC;
+            case RG11_EAC:
+                return GL_COMPRESSED_RG11_EAC;
+            case SIGNED_R11_EAC:
+                return SIGNED_R11_EAC;
+            case SIGNED_RG11_EAC:
+                return SIGNED_RG11_EAC;
+            default:
+                return -1;
+        }
+    }
+
+    /**
+     * Retrieve the actual texture width in pixels.
+     *
+     * @param header {@link ByteBuffer} The PKM file header.
+     * @return {@code int} The actual texture width.
+     */
+    public static int getWidth(ByteBuffer header) {
+        return (0xFFFF & header.getShort(ETC2_PKM_WIDTH_OFFSET));
+    }
+
+    /**
+     * Retrieve the actual texture height in pixels.
+     *
+     * @param header {@link ByteBuffer} The PKM file header.
+     * @return {@code int} The actual texture height.
+     */
+    public static int getHeight(ByteBuffer header) {
+        return (0xFFFF & header.getShort(ETC2_PKM_HEIGHT_OFFSET));
+    }
+
+    /**
+     * Retrieve the encoded texture width in pixels.
+     *
+     * @param header {@link ByteBuffer} The PKM file header.
+     * @return {@code int} The encoded texture width.
+     */
+    public static int getEncodedWidth(ByteBuffer header) {
+        return (0xFFFF & header.getShort(ETC2_PKM_ENCODED_WIDTH_OFFSET));
+    }
+
+    /**
+     * Retrieve the encoded texture height in pixels.
+     *
+     * @param header {@link ByteBuffer} The PKM file header.
+     * @return {@code int} The encoded texture height.
+     */
+    public static int getEncodedHeight(ByteBuffer header) {
+        return (0xFFFF & header.getShort(ETC2_PKM_ENCODED_HEIGHT_OFFSET));
+    }
+
+    /**
+     * Return the size of the encoded image data (does not include the size of the PKM header).
+     *
+     * @param width {@code int} The actual texture width in pixels.
+     * @param height {@code int} The actual texture height in pixels.
+     * @return {@code int} The number of bytes required to encode this data.
+     */
+    public static int getEncodedDataSize(int width, int height) {
+        return ((((width + 3) & ~3) * ((height + 3) & ~3)) >> 1);
+    }
+}

--- a/include/vrb/FileReader.h
+++ b/include/vrb/FileReader.h
@@ -8,6 +8,7 @@
 
 #include "vrb/Forward.h"
 #include "vrb/MacroUtils.h"
+#include "vrb/gl.h"
 
 #include <string>
 #include <memory>
@@ -20,7 +21,7 @@ public:
   virtual void LoadFailed(const int aFileHandle, const std::string& aReason) = 0;
   virtual void ProcessRawFileChunk(const int aFileHandle, const char* aBuffer, const size_t aSize) = 0;
   virtual void FinishRawFile(const int aFileHandle) = 0;
-  virtual void ProcessImageFile(const int aFileHandle, std::unique_ptr<uint8_t[]>& aImage, const int aWidth, const int aHeight) = 0;
+  virtual void ProcessImageFile(const int aFileHandle, std::unique_ptr<uint8_t[]>& aImage, const uint64_t aImageLength, const int aWidth, const int aHeight, const GLenum aFormat) = 0;
 protected:
   FileHandler() {}
   virtual ~FileHandler() {}

--- a/include/vrb/FileReaderAndroid.h
+++ b/include/vrb/FileReaderAndroid.h
@@ -10,6 +10,7 @@
 #include "vrb/Forward.h"
 #include "vrb/MacroUtils.h"
 
+#include "vrb/gl.h"
 #include <jni.h>
 #include <memory>
 
@@ -22,7 +23,7 @@ public:
   void ReadImageFile(const std::string& aFileName, FileHandlerPtr aHandler) override;
   void Init(JNIEnv* aEnv, jobject& aAssetManager, const ClassLoaderAndroidPtr& classLoader);
   void Shutdown();
-  void ProcessImageFile(const int aFileHandle, std::unique_ptr<uint8_t[]>& aImage, const int aWidth, const int aHeight);
+  void ProcessImageFile(const int aFileHandle, std::unique_ptr<uint8_t[]>& aImage, const uint64_t aImageLength, const int aWidth, const int aHeight, const GLenum aFormat);
   void ImageFileLoadFailed(const int aFileHandle, const std::string& aReason);
 protected:
   struct State;

--- a/include/vrb/ParserObj.h
+++ b/include/vrb/ParserObj.h
@@ -61,7 +61,7 @@ public:
   void LoadFailed(const int aFileHandle, const std::string& aReason) override ;
   void ProcessRawFileChunk(const int aFileHandle, const char* aBuffer, const size_t aSize) override ;
   void FinishRawFile(const int aFileHandle) override;
-  void ProcessImageFile(const int aFileHandle, std::unique_ptr<uint8_t[]>& aImage, const int aWidth, const int aHeight) override;
+  void ProcessImageFile(const int aFileHandle, std::unique_ptr<uint8_t[]>& aImage, const uint64_t aImageLength, const int aWidth, const int aHeight, const GLenum aFormat) override;
 
   // ParserObj Interface
   void LoadModel(const std::string& aFileName);

--- a/include/vrb/TextureCubeMap.h
+++ b/include/vrb/TextureCubeMap.h
@@ -24,7 +24,7 @@ public:
                    const std::string& aFileXPos, const std::string& aFileXNeg,
                    const std::string& aFileYPos, const std::string& aFileYNeg,
                    const std::string& aFileZPos, const std::string& aFileZNeg);
-  void SetRGBData(const GLenum aFaceTarget, std::unique_ptr<uint8_t[]>& aImage, const int aWidth, const int aHeight, const int aChannels);
+  void SetImageData(const GLenum aFaceTarget, std::unique_ptr<uint8_t[]>& aImage, const uint64_t aImageLength, const int aWidth, const int aHeight, const GLenum aFormat);
 protected:
   struct State;
   TextureCubeMap(State& aState, CreationContextPtr& aContext);

--- a/include/vrb/TextureGL.h
+++ b/include/vrb/TextureGL.h
@@ -20,7 +20,7 @@ class TextureGL : public Texture, protected ResourceGL {
 public:
   static TextureGLPtr Create(CreationContextPtr& aContext);
 
-  void SetRGBData(std::unique_ptr<uint8_t[]>& aImage, const int aWidth, const int aHeight, const int aChannels);
+  void SetImageData(std::unique_ptr<uint8_t[]>& aImage, const uint64_t aImageLength, const int aWidth, const int aHeight, const GLenum aFormat);
 protected:
   struct State;
   TextureGL(State& aState, CreationContextPtr& aContext);

--- a/src/CreationContext.cpp
+++ b/src/CreationContext.cpp
@@ -37,7 +37,7 @@ public:
   void LoadFailed(const int aFileHandle, const std::string& aReason) override;
   void ProcessRawFileChunk(const int aFileHandle, const char* aBuffer, const size_t aSize) override {};
   void FinishRawFile(const int aFileHandle) override {};
-  void ProcessImageFile(const int aFileHandle, std::unique_ptr<uint8_t[]>& aImage, const int aWidth, const int aHeight) override;
+  void ProcessImageFile(const int aFileHandle, std::unique_ptr<uint8_t[]>& aImage, const uint64_t aImageLength, const int aWidth, const int aHeight, const GLenum aFormat) override;
   TextureHandler() {}
   ~TextureHandler() {}
 protected:
@@ -64,9 +64,9 @@ TextureHandler::LoadFailed(const int aFileHandle, const std::string& aReason) {
 }
 
 void
-TextureHandler::ProcessImageFile(const int aFileHandle, std::unique_ptr<uint8_t[]>& aImage, const int aWidth, const int aHeight) {
+TextureHandler::ProcessImageFile(const int aFileHandle, std::unique_ptr<uint8_t[]>& aImage, const uint64_t aImageLength, const int aWidth, const int aHeight, const GLenum aFormat) {
   if (mTexture) {
-    mTexture->SetRGBData(aImage, aWidth, aHeight, 4);
+    mTexture->SetImageData(aImage, aImageLength, aWidth, aHeight, aFormat);
   }
 }
 

--- a/src/ParserObj.cpp
+++ b/src/ParserObj.cpp
@@ -465,7 +465,7 @@ ParserObj::FinishRawFile(const int aFileHandle) {
 }
 
 void
-ParserObj::ProcessImageFile(const int aFileHandle, std::unique_ptr<uint8_t[]>& aImage, const int aWidth, const int aHeight) {
+ParserObj::ProcessImageFile(const int aFileHandle, std::unique_ptr<uint8_t[]>& aImage, const uint64_t aImageLength, const int aWidth, const int aHeight, const GLenum aFormat) {
 
 }
 

--- a/src/TextureCache.cpp
+++ b/src/TextureCache.cpp
@@ -36,7 +36,8 @@ TextureCache::Init(CreationContextPtr& aContext) {
   const size_t kArraySize = kDefaultImageDataSize * sizeof(uint32_t);
   std::unique_ptr<uint8_t[]> data = std::make_unique<uint8_t[]>(kArraySize);
   memcpy(data.get(), (void*)kDefaultImageData, kArraySize);
-  m.defaultTexture->SetRGBData(data, kDefaultImageDataWidth, kDefaultImageDataHeight, 4);
+  uint64_t length = kDefaultImageDataWidth * kDefaultImageDataHeight * 4;
+  m.defaultTexture->SetImageData(data, length, kDefaultImageDataWidth,  kDefaultImageDataHeight, GL_RGBA);
 }
 
 void


### PR DESCRIPTION
* Improve RGBA texture loading times using java.nio.ByteBuffer direct JNI allocations. Also removed the need for the loop used to swap red and blue channels.
* Add support for OpenGL compressed textures (ETC2)

depends on https://github.com/MozillaReality/vrb/pull/39