### PR TITLE
Generate mipmaps for cube map textures, and enable linear filtering.

### DIFF
--- a/src/TextureCubeMap.cpp
+++ b/src/TextureCubeMap.cpp
@@ -162,6 +162,14 @@ TextureCubeMap::State::CreateTexture() {
   for (auto param = intMap.begin(); param != intMap.end(); param++) {
     VRB_GL_CHECK(glTexParameteri(target, param->first, param->second));
   }
+    VRB_GL_CHECK(glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_BASE_LEVEL, 0));
+    VRB_GL_CHECK(glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MAX_LEVEL, 5));
+    VRB_GL_CHECK(glGenerateMipmap(GL_TEXTURE_CUBE_MAP));
+    VRB_GL_CHECK(glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MAG_FILTER, GL_LINEAR));
+    VRB_GL_CHECK(glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MIN_FILTER, GL_LINEAR));
+    VRB_GL_CHECK(glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
+    VRB_GL_CHECK(glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
+    VRB_GL_CHECK(glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE));
   dirty = false;
 }
 


### PR DESCRIPTION
This fixes the aliasing effect in the FxR background environment.