### PR TITLE
Add support for externally created textures in the Cubemap

### DIFF
--- a/include/vrb/FBO.h
+++ b/include/vrb/FBO.h
@@ -28,9 +28,10 @@ public:
                         const int32_t aWidth,
                         const int32_t aHeight,
                         const FBO::Attributes& aAttributtes = {});
-  void Bind();
+  void Bind(GLenum target = GL_FRAMEBUFFER);
   void Unbind();
   const FBO::Attributes& GetAttributes() const;
+  GLuint GetHandle() const;
 protected:
   struct State;
   FBO(State& aState);

--- a/include/vrb/Texture.h
+++ b/include/vrb/Texture.h
@@ -22,6 +22,7 @@ public:
   GLenum GetTarget() const;
   void SetName(const std::string& aName);
   void SetTextureParameter(GLenum aName, GLint aParam);
+  GLuint GetHandle() const;
 protected:
   struct State;
   Texture(State& aState, CreationContextPtr& aContext);

--- a/include/vrb/TextureCubeMap.h
+++ b/include/vrb/TextureCubeMap.h
@@ -18,7 +18,7 @@ namespace vrb {
 
 class TextureCubeMap : public Texture, protected ResourceGL {
 public:
-  static TextureCubeMapPtr Create(CreationContextPtr& aContext);
+  static TextureCubeMapPtr Create(CreationContextPtr& aContext, GLuint aExternalTexture = 0);
 
   static void Load(CreationContextPtr& aContext, const TextureCubeMapPtr& aTexture,
                    const std::string& aFileXPos, const std::string& aFileXNeg,

--- a/src/FBO.cpp
+++ b/src/FBO.cpp
@@ -19,8 +19,9 @@ struct FBO::State {
   GLuint depth;
   GLuint fbo;
   Attributes attributes;
+  GLenum boundTarget;
 
-  State() : depth(0), fbo(0), valid(false) {}
+  State() : boundTarget(GL_FRAMEBUFFER), depth(0), fbo(0), valid(false) {}
   void Clear() {
     if (depth) {
       if (attributes.multiview) {
@@ -160,19 +161,26 @@ FBO::SetTextureHandle(const GLuint aHandle,
 }
 
 void
-FBO::Bind() {
+FBO::Bind(GLenum aTarget) {
   if (!m.valid) { return; }
-  VRB_GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, m.fbo));
+
+  m.boundTarget = aTarget;
+  VRB_GL_CHECK(glBindFramebuffer(aTarget, m.fbo));
 }
 
 void
 FBO::Unbind() {
-  VRB_GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, 0));
+  VRB_GL_CHECK(glBindFramebuffer(m.boundTarget, 0));
 }
 
 const FBO::Attributes&
 FBO::GetAttributes() const {
   return m.attributes;
+}
+
+GLuint
+FBO::GetHandle() const {
+  return m.fbo;
 }
 
 FBO::FBO(State& aState) : m(aState) {}

--- a/src/Texture.cpp
+++ b/src/Texture.cpp
@@ -33,6 +33,11 @@ Texture::GetTarget() const {
   return m.target;
 }
 
+GLuint
+Texture::GetHandle() const {
+  return m.texture;
+}
+
 void
 Texture::SetName(const std::string& aName) {
   m.name = aName;


### PR DESCRIPTION
Required to hook a TimeWarp layer in the existing Cubemap loading code